### PR TITLE
Add class visitor to annotation descriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.knockturnmc</groupId>
     <artifactId>knockturn-commons</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1-SNAPSHOT</version>
 
     <name>Knockturn Commons</name>
     <description>Common Utilities</description>
@@ -21,20 +21,19 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.16</version>
+            <version>1.18.12</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.30</version>
         </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/src/main/java/com/knockturnmc/api/ext/loader/descriptors/ModuleAnnotationDescriptor.java
+++ b/src/main/java/com/knockturnmc/api/ext/loader/descriptors/ModuleAnnotationDescriptor.java
@@ -9,6 +9,8 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.zip.ZipFile;
 
@@ -18,10 +20,18 @@ public class ModuleAnnotationDescriptor implements ModuleDescriptor {
     private String moduleClassName;
 
     private File sourceFile;
+    private Consumer<Class<?>> classObserver;
 
     public ModuleAnnotationDescriptor(File sourceFile) {
+        this(sourceFile, c -> {
+        });
+    }
+
+    public ModuleAnnotationDescriptor(File sourceFile, Consumer<Class<?>> classObserver) {
         if (sourceFile == null) throw new NullPointerException("Source file for module was null!");
         this.sourceFile = sourceFile;
+
+        this.classObserver = classObserver;
     }
 
     /**
@@ -44,6 +54,7 @@ public class ModuleAnnotationDescriptor implements ModuleDescriptor {
                                 return null;
                             }
                         }).filter(Objects::nonNull)
+                        .peek(this.classObserver)
                         .filter(c -> c.isAnnotationPresent(Module.class))
                         .filter(Loadable.class::isAssignableFrom)
                         .collect(Collectors.toCollection(ArrayList::new));


### PR DESCRIPTION
As the module loaders annotation descriptors loads all java classes to
find the one annotated module class, this commit adds a class visitor to
the module annotation descriptor.
This allows users to collect other files inside the jar while the module
is loading, allowing those classes to be used as well.

To reflect this, non breaking, change the version number was increased
from 1.4.0 to 1.4.1.